### PR TITLE
Improve build time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+          ext.alwaysUpdateBuildId = false
+          ext.enableCrashlytics = false
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,5 @@ org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
- Disable Crashlytics in debug.
- Disable Crashlytics updating the build id.
- Enable parallel build
- Enable build caching